### PR TITLE
Initial support for meson in g-speak template

### DIFF
--- a/gspeak.py
+++ b/gspeak.py
@@ -34,6 +34,21 @@ def get_yobuild(g_speak_version):
     # NOTE: if the following line fails, please install the Oblong obs package
     return "/opt/oblong/deps-64-" + subprocess.check_output(["obs", "yovo2yoversion", g_speak_version]).rstrip()
 
+def get_yobuild_major(g_speak_version):
+    '''
+    Look up which version of yobuild this gspeak depends on
+    '''
+    p = re.compile(r'YOBUILD_PREFIX.*".*-(.*)"')
+    with open("/opt/oblong/g-speak%s/include/libLoam/c/ob-vers-gen.h" % g_speak_version, 'r') as f:
+        for line in f:
+            m = p.search(line)
+            if (m):
+                return m.group(1)
+
+    # If g-speak wasn't installed, fall back to asking obs
+    # NOTE: if the following line fails, please install the Oblong obs package
+    return subprocess.check_output(["obs", "yovo2yoversion", g_speak_version]).rstrip()
+
 def get_cef_branch(g_speak_version):
     '''
     Look up which cef this g-speak's webthing depends on
@@ -58,12 +73,15 @@ def obi_new(**kwargs):
 
     # On entry, kwargs['project_path'] is the directory to create and populate
     # from the files in the templates subdirectory next to this file
+    # $G_SPEAK/lib/cmake/ObGenerateProject.cmake is an alternative implementation
+    # that should always use the same template syntax and parameters.
     templates_path = os.path.join(os.path.dirname(__file__), 'templates')
 
     project_name = kwargs['project_name']
     project_path = kwargs['project_path']
     g_speak_xy = kwargs['g_speak_version']
     kwargs['yobuild'] = get_yobuild(g_speak_xy)
+    kwargs['yobuild_major'] = get_yobuild_major(g_speak_xy)
     kwargs['cef_branch'] = get_cef_branch(g_speak_xy)
 
     env = jinja2.Environment(loader=jinja2.PackageLoader(__name__),

--- a/templates/README.md
+++ b/templates/README.md
@@ -75,18 +75,14 @@ Try 'ob-set-defaults --help' for more info.
 ### Build
 ```bash
 cd build
-cmake -DG_SPEAK_HOME=/opt/oblong/g-speak{{g_speak_version}} ..
+cmake [-DG_SPEAK_HOME=/opt/oblong/g-speak{{g_speak_version}}] ..
 ninja
 ```
 
 Or, to use meson,
 ```bash
-YOBUILD={{yobuild}}
-G_SPEAK_HOME=/opt/oblong/g-speak{{g_speak_version}}
-export BOOST_ROOT=$YOBUILD
-export PKG_CONFIG_PATH=$YOBUILD/lib/pkgconfig:$YOBUILD/lib/x86_64-linux-gnu/pkgconfig:$G_SPEAK_HOME/lib/pkgconfig
 cd build
-meson ..
+obenv meson ..
 ninja
 ```
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -31,6 +31,17 @@ Where `<room-name>` is the name of one of the keys specified in the `rooms` map 
 	obi stop [<room-name>]
 
 
+## IDE Integration
+
+obi generates the compile_commands.json file
+used by many tools and IDEs to understand your project
+and offer information about identifiers when you mouse over them.
+
+### Visual Studio Code
+
+obi does not yet create the launch.json file Visual Studio Code
+needs to run your program.  If you want it to, please let us know.
+
 ## Sublime Text Users
 
 This project has a [sublime-project file]({{project_name}}.sublime-project) that comes equipped with some useful build systems:
@@ -39,20 +50,15 @@ This project has a [sublime-project file]({{project_name}}.sublime-project) that
 - `obi-go`: build and run the app
 - `obi-go:my-room`: build and run the app in your custom room *NOTE:* Requires custom setup in your project.yaml
 
+## Switching to Meson
 
-## Riding without obi
+By default, 'obi build' will use CMake, which reads CMakeLists.txt to figure out how to build your project.
 
-### Build
-```bash
-cd build
-cmake -DG_SPEAK_HOME=/opt/oblong/g-speak{{g_speak_version}} ..
-make -j8 -l8
-```
+CMake works, but is not beloved by all.
 
-### Run
-```bash
-build/{{project_name}} [(<screen.protein> <feld.protein>)]
-```
+Meson is a simpler, more modern alternative to CMake.
+If you want to try it, edit project.yaml and uncomment the definition for meson-args.
+'obi build' will then use meson, which reads meson.build to figure out how to build your project.
 
 ### Change default g-speak version
 obi detects the g-speak version present at the time, and sets that
@@ -64,6 +70,37 @@ ob-set-defaults --g-speak 4.2
 ```
 Try 'ob-set-defaults --help' for more info.
 
+## Riding without obi
+
+### Build
+```bash
+cd build
+cmake -DG_SPEAK_HOME=/opt/oblong/g-speak{{g_speak_version}} ..
+ninja
+```
+
+Or, to use meson,
+```bash
+YOBUILD={{yobuild}}
+G_SPEAK_HOME=/opt/oblong/g-speak{{g_speak_version}}
+export BOOST_ROOT=$YOBUILD
+export PKG_CONFIG_PATH=$YOBUILD/lib/pkgconfig:$YOBUILD/lib/x86_64-linux-gnu/pkgconfig:$G_SPEAK_HOME/lib/pkgconfig
+cd build
+meson ..
+ninja
+```
+
+### Run
+```bash
+build/{{project_name}} [(<screen.protein> <feld.protein>)]
+```
+
+### Rebuild
+```bash
+cd build
+ninja
+```
+
 ### Build packages (mostly Oblong-specific)
 The tool bau, included with the g-speak platform SDK,
 is a bit like obi, but centers around building packages
@@ -74,7 +111,6 @@ and the default recipes in /usr/bin/bau-defaults.
 
 For instance,
 ```bash
-bau all
+bau build
 ```
 It takes the same options as ob-set-defaults.  Try 'bau --help' and 'bau help' for more info.
-

--- a/templates/debian/control
+++ b/templates/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper (>= 7.0.50~),
 ## Ubuntu 17.04 has cmake 3.7.2, which is great.
 ##             oblong-yobuild12-cmake | cmake (>= 3.7.0),
 ## However, ubuntu 16.04's 3.5.1 is otherwise ok, so let developers slide for now
-               oblong-yobuild12-cmake | cmake (>= 3.5.1),
+               oblong-yobuild{{yobuild_major}}-cmake | cmake (>= 3.5.1),
 ##  We default to building with ninja
                ninja-build,
 ##  If ubuntu >= 16.04, pull in strip-nondeterminism, for reproducible builds

--- a/templates/debian/rules
+++ b/templates/debian/rules
@@ -22,7 +22,7 @@ G_SPEAK_HOME=/opt/oblong/g-speak{{g_speak_version}}
 
 # YOBUILD is where updated system-y libraries for this version of g-speak live.
 # ob-set-defaults sets this based on the g-speak version.
-YOBUILD=/opt/oblong/deps-64-12
+YOBUILD={{yobuild}}
 
 # Cmake options passed to ob-set-defaults (careful, quoting is treacherous here)
 CMAKE_GENERATOR=Ninja

--- a/templates/meson.build
+++ b/templates/meson.build
@@ -1,0 +1,47 @@
+project('{{project_name}}', 'cpp',
+  version : '1.0.0',
+  license : 'proprietary',
+  default_options : [
+    'werror=true',
+    'warning_level=2',
+    'cpp_std=c++11',
+    'buildtype=debug',
+    'b_ndebug=if-release',
+  ]
+)
+
+maybe_cpp_flags = [
+      #---- Turn on ALL THE WARNINGS! by default----
+      '-Wall',
+      '-Wempty-body',
+      '-Wpointer-arith',
+      '-Wshadow',
+      '-Wtype-limits',
+      '-Wvla',
+      '-Wwrite-strings',
+      '-fdiagnostics-show-option',
+      #---- OK, but not the annoying ones ------
+      #'-Wno-error=overloaded-virtual',
+      '-Wno-error=suggest-override',    # boost/smart_ptr/detail/local_counted_base.hpp... meson doesn't use -isystem :-(
+]
+cpp_compiler = meson.get_compiler('cpp')
+cpp_flags = cpp_compiler.get_supported_arguments(maybe_cpp_flags)
+
+# Find system libraries this project depends on.
+libs = [
+   'libAfferent',
+   'libNoodoo',
+   'libTwillig',
+]
+project_deps = []
+foreach lib : libs
+   project_deps += dependency(lib, required : true)
+endforeach
+
+# Build the project, and install it if asked (via 'ninja install').
+executable(
+   '{{project_name}}',
+   'src/{{project_name}}.cpp',
+   cpp_args : cpp_flags,
+   dependencies : project_deps,
+   install : true)

--- a/templates/project.yaml
+++ b/templates/project.yaml
@@ -9,14 +9,19 @@ name: '{{project_name}}'
 # ----------
 # Comma-separated list of command line arguments passed to cmake
 cmake-args: ['-DCMAKE_BUILD_TYPE=RelWithDebInfo',
-             '-DCMAKE_EXPORT_COMPILE_COMMANDS=1']
+             '-DCMAKE_EXPORT_COMPILE_COMMANDS=1',
+             '-GNinja']
 
-# Comma-separated list of arguments passed to cmake --build
-# These are sensitive to the build system generator
-# specified in the cmake-args step
-build-args: ['-j8', '-l8']
+# If meson-args is defined, obi will use meson rather than cmake.
+# Comma-separated list of command line arguments passed to meson
+#meson-args: []
 
-# The directory to perform the out-of-source cmake build
+# Comma-separated list of arguments passed to cmake --build or ninja,
+# e.g. '-v', '-j1' for a clean log.
+# These are sensitive to any build system generator specified in cmake-args.
+build-args: []
+
+# The directory to perform the out-of-source build
 build-dir: "build"
 
 # Override the default obi build task

--- a/templates/src/@PROJECT@.cpp
+++ b/templates/src/@PROJECT@.cpp
@@ -18,7 +18,7 @@ ObColor palette[3] = {
 
 ArgParse::apint demo_shift;
 
-ObRetort Setup (VFBunch *bunch, Atmosphere *atm)
+ObRetort Setup (VFBunch *, Atmosphere *)
 {
   const int N = VisiFeld::NumAllVisiFelds ();
   for (int i = 0; i < N; ++i)


### PR DESCRIPTION
Requires g-speak 5.1 or later.

Also avoids hardcoding YOBUILD.